### PR TITLE
edited reset cfg parameters

### DIFF
--- a/joebvp/VPmeasure.py
+++ b/joebvp/VPmeasure.py
@@ -943,7 +943,14 @@ def concatenate_all(spectrum, filepath='.', outparfile='.VP'):
     # makes compiledVPoutputs.dat
     jbu.concatenate_line_tables("all_VP.txt")
 
-    reload(cfg)  # Clear out the LSFs from the last fit
+    #reload(cfg)  # Clear out the LSFs from the last fit
+    cfg.lsfs = []
+    cfg.fgs = []
+    cfg.wavegroups = []
+    cfg.wgidxs = []
+    cfg.uqwgidxs = []
+    cfg.fitidx = []
+
     cfg.spectrum = spectrum
 
     # makes pdf from compiledVPoutputs.dat

--- a/joebvp/cfg.py
+++ b/joebvp/cfg.py
@@ -68,8 +68,8 @@ contoutfile = outputdir + 'continua.dat'
 largeVPparfile = outputdir + '_VP_log.dat'
 defaultcol = 13.1
 defaultb = 20.0
-defaultvlim = 1000.
-lowblim = 4.
+defaultvlim = 500.
+lowblim = 6.
 upperblim = 85.
 upperblim_HI = 210.
 

--- a/joebvp/cfg.py
+++ b/joebvp/cfg.py
@@ -44,8 +44,8 @@ else:  # this is for the casual user
     slits=['NA','NA']  # Required when using instr = 'COS'
     lps=['2','2']  # Lifetime positions; required when using instr = 'COS'
     spectral_gaps = [[0,1162.5], [1198,1201.5], [1213.3, 1217.93], [1299.3,1321.6],[1596,1612.8],[1782,2000]]
-    pixel_scales = ['N/A','N/A']  # Required when using instr = 'Gaussian' (in Angstroms)
-    fwhms = ['N/A','N/A']  # Required when using instr = 'Gaussian' (in Angstroms)
+    pixel_scales = ['N/A','N/A']  # Required when using instr = 'Gaussian' (in Angstroms; float)
+    fwhms = ['N/A','N/A']  # Required when using instr = 'Gaussian' (in Angstroms; float)
 
 # fundamental constants
 echarge = 4.803204505713468e-10
@@ -68,7 +68,7 @@ contoutfile = outputdir + 'continua.dat'
 largeVPparfile = outputdir + '_VP_log.dat'
 defaultcol = 13.1
 defaultb = 20.0
-defaultvlim = 500.
+defaultvlim = 1000.
 lowblim = 6.
 upperblim = 85.
 upperblim_HI = 210.


### PR DESCRIPTION
"reload(cfg)" clears out all the cfg parameters including the instrument and grating, so once a fitting process is done, the rest of the fittings only apply the default setting. It should be replaced by this to keep the initial setting and only clear out the LSFs. 